### PR TITLE
Add authorization

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,6 +57,8 @@ externalDocs:
 tags:
   - name: DMP
     description: DMP-related endpoints
+security:
+  - BearerAuth: []
 paths:
   /dmps:
     get:
@@ -505,6 +507,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/UnsupportedMediaTypeError"
+
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+
   schemas:
     #region IDs
 


### PR DESCRIPTION
Added the security schema `BearerAuth` and activated it globally (for every endpoint).
I added no `bearerFormat`, since I assume that every tool would use different token types (e.g. DAMAP would use JWTs). Other options is to fixate on a single Format but that would need to be discussed

Closes #6 