### PR TITLE
Add quotes to yes and no enum values

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1565,8 +1565,8 @@ components:
         personal_data:
           type: string
           enum:
-            - yes
-            - no
+            - "yes"
+            - "no"
             - unknown
           title: Personal Data
           description: "To indicate whether a dataset contains personal data. Personal
@@ -1611,8 +1611,8 @@ components:
         sensitive_data:
           type: string
           enum:
-            - yes
-            - no
+            - "yes"
+            - "no"
             - unknown
           title: Sensitive Data
           description: "To indicate whether a dataset contains sensitive data. Sensitive


### PR DESCRIPTION
This PR adds quotes to the enum values `yes` and `no` for `personal_data` and `sensitive_data`, since otherwise they would get converted to boolean values `true` and `false´.

See issue https://github.com/RDA-DMP-Common/common-madmp-api/issues/25 for more info.