### PR TITLE
Replace data_access value "shared" with "restricted"

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1473,10 +1473,10 @@ components:
       type: string
       enum:
         - open
-        - shared
+        - restricted
         - closed
       title: Data Access
-      description: "Indicates access mode for data. Allowed values: open, shared, closed"
+      description: "Indicates access mode for data. Allowed values: open, restricted, closed"
       examples:
         - open
     Dataset:


### PR DESCRIPTION
Data_Access has as allowed values:
- `open`
- `shared`
- `closed`

But `shared` doesnt really make sense in this context and it should rather be `restricted`.

Partner PR in the common standard repo: https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard/pull/150