### PR TITLE
Specify byte size format as int64 to avoid overflow

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1808,6 +1808,7 @@ components:
             - "2030-06-30"
         byte_size:
           type: integer
+          format: int64
           title: Byte Size
           description: Size in bytes.
           examples:


### PR DESCRIPTION
## Summary

This PR specifies that the `byte_size` field in `Distribution` should be an `int64` (a Java long) instead of the default `int32`. `int32` is inadequate for this variable, since any value more than roughly 2.2 GB would already result in an integer overflow.